### PR TITLE
rename Player variables and clientModeGame / clientLanguageId

### DIFF
--- a/client/src/main/java/Class362.java
+++ b/client/src/main/java/Class362.java
@@ -61,7 +61,7 @@ public final class Class362 implements Runnable {
 		if (this.aPrivilegedRequest7 == null) {
 			try {
 				@Pc(23) int local23 = ModeWhere.LIVE == Static2.aModeWhere1 ? 80 : Static527.aClass229_3.worldId + 7000;
-				this.aPrivilegedRequest7 = Static446.aSignlink6.method8992(new URL("http://" + Static527.aClass229_3.aString60 + ":" + local23 + "/news.ws?game=" + Static392.aModeGame4.id));
+				this.aPrivilegedRequest7 = Static446.aSignlink6.method8992(new URL("http://" + Static527.aClass229_3.aString60 + ":" + local23 + "/news.ws?game=" + Static392.clientModeGame.id));
 			} catch (@Pc(54) MalformedURLException local54) {
 				return true;
 			}

--- a/client/src/main/java/Player.java
+++ b/client/src/main/java/Player.java
@@ -7,13 +7,13 @@ import org.openrs2.deob.annotation.Pc;
 public final class Player extends PathingEntity {
 
 	@OriginalMember(owner = "client!ca", name = "Sc", descriptor = "Ljava/lang/String;")
-	public String aString8;
+	public String name1;
 
 	@OriginalMember(owner = "client!ca", name = "Mc", descriptor = "Lclient!ju;")
 	public PlayerAppearance aPlayerAppearance1;
 
 	@OriginalMember(owner = "client!ca", name = "xd", descriptor = "Ljava/lang/String;")
-	public String aString9;
+	public String name2;
 
 	@OriginalMember(owner = "client!ca", name = "bd", descriptor = "I")
 	public int anInt1441;
@@ -49,7 +49,7 @@ public final class Player extends PathingEntity {
 	public boolean aBoolean126 = false;
 
 	@OriginalMember(owner = "client!ca", name = "cd", descriptor = "I")
-	public int anInt1437 = 0;
+	public int combatLevel1 = 0;
 
 	@OriginalMember(owner = "client!ca", name = "Ad", descriptor = "I")
 	public int anInt1436 = 0;
@@ -67,7 +67,7 @@ public final class Player extends PathingEntity {
 	public boolean aBoolean129 = false;
 
 	@OriginalMember(owner = "client!ca", name = "Fd", descriptor = "I")
-	public int anInt1444 = 0;
+	public int combatLevel2 = 0;
 
 	@OriginalMember(owner = "client!ca", name = "zd", descriptor = "Z")
 	public boolean aBoolean128 = false;
@@ -202,7 +202,7 @@ public final class Player extends PathingEntity {
 	@Override
 	protected int method9320(@OriginalArg(0) int arg0) {
 		if (arg0 != 0) {
-			this.anInt1444 = -112;
+			this.combatLevel2 = -112;
 		}
 		return this.anInt1443;
 	}
@@ -485,22 +485,22 @@ public final class Player extends PathingEntity {
 			local332[local184] = local191;
 		}
 		this.anInt1443 = arg0.g2();
-		this.aString8 = arg0.gjstr();
+		this.name1 = arg0.gjstr();
 		if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == this) {
-			Static515.aString96 = this.aString8;
+			Static515.aString96 = this.name1;
 		}
-		this.aString9 = this.aString8;
-		this.anInt1444 = arg0.g1();
+		this.name2 = this.name1;
+		this.combatLevel2 = arg0.g1();
 		if (local40) {
 			this.anInt1436 = arg0.g2();
-			this.anInt1437 = this.anInt1444;
+			this.combatLevel1 = this.combatLevel2;
 			if (this.anInt1436 == 65535) {
 				this.anInt1436 = -1;
 			}
 			this.anInt1471 = -1;
 		} else {
 			this.anInt1436 = 0;
-			this.anInt1437 = arg0.g1();
+			this.combatLevel1 = arg0.g1();
 			this.anInt1471 = arg0.g1();
 			if (this.anInt1471 == 255) {
 				this.anInt1471 = -1;
@@ -630,7 +630,7 @@ public final class Player extends PathingEntity {
 
 	@OriginalMember(owner = "client!ca", name = "a", descriptor = "(ZI)Ljava/lang/String;")
 	public String method1422() {
-		return this.aString9;
+		return this.name2;
 	}
 
 	@OriginalMember(owner = "client!ca", name = "a", descriptor = "(ZZ)Ljava/lang/String;")
@@ -657,7 +657,7 @@ public final class Player extends PathingEntity {
 				local40[this.aByte31] = -1;
 			}
 		}
-		local5 = local5 + this.aString8;
+		local5 = local5 + this.name1;
 		if (Static377.aStringArray30 != null) {
 			local5 = local5 + Static377.aStringArray30[this.aByte31];
 		}
@@ -674,7 +674,7 @@ public final class Player extends PathingEntity {
 			if (super.aClass80_3.aString20 == null) {
 				return null;
 			}
-			if (Static133.anInt2458 == 0 || Static133.anInt2458 == 3 || Static133.anInt2458 == 1 && Static362.method5241(arg0 + 3109, this.aString9)) {
+			if (Static133.anInt2458 == 0 || Static133.anInt2458 == 3 || Static133.anInt2458 == 1 && Static362.method5241(arg0 + 3109, this.name2)) {
 				return super.aClass80_3;
 			}
 		}

--- a/client/src/main/java/Protocol.java
+++ b/client/src/main/java/Protocol.java
@@ -106,7 +106,7 @@ public class Protocol {
             arg0.packetType = null;
             return true;
         } else if (Static632.ServerProt229 == arg0.packetType) {
-            Static331.aString52 = arg0.anInt3648 <= 2 ? LocalizedText.WALK_HERE.get(Static51.anInt1052) : local11.gjstr();
+            Static331.aString52 = arg0.anInt3648 <= 2 ? LocalizedText.WALK_HERE.get(Static51.clientLanguageId) : local11.gjstr();
             Static331.anInt5439 = arg0.anInt3648 <= 0 ? -1 : local11.g2();
             if (Static331.anInt5439 == 65535) {
                 Static331.anInt5439 = -1;
@@ -1794,7 +1794,7 @@ public class Protocol {
                                                                                         Static87.aClass241Array1[local1449].anInt6148 = local1409;
                                                                                         Static87.aClass241Array1[local1449].aByte99 = local7377;
                                                                                         Static87.aClass241Array1[local1449].aString65 = local1427;
-                                                                                        if (local627.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9)) {
+                                                                                        if (local627.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2)) {
                                                                                             Static682.aByte142 = local7377;
                                                                                         }
                                                                                         Static352.anInt5754 = Static642.anInt9599;
@@ -1817,7 +1817,7 @@ public class Protocol {
                                                                                 }
                                                                                 Static87.aClass241Array1[local1449 + 1] = local7394;
                                                                                 Static706.anInt10633++;
-                                                                                if (local627.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9)) {
+                                                                                if (local627.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2)) {
                                                                                     Static682.aByte142 = local7377;
                                                                                 }
                                                                             }
@@ -1849,12 +1849,12 @@ public class Protocol {
                                                                             local526 = local11.g2();
                                                                             local1409 = local11.g1();
                                                                             local6565 = (local526 & 0x8000) != 0;
-                                                                            if (local7724.aString9 != null && local7724.aPlayerAppearance1 != null) {
+                                                                            if (local7724.name2 != null && local7724.aPlayerAppearance1 != null) {
                                                                                 local1425 = false;
                                                                                 if (local1409 <= 1) {
                                                                                     if (!local6565 && (Static389.aBoolean459 && !Static34.aBoolean62 || Static617.aBoolean724)) {
                                                                                         local1425 = true;
-                                                                                    } else if (Static71.method1524(local7724.aString9)) {
+                                                                                    } else if (Static71.method1524(local7724.name2)) {
                                                                                         local1425 = true;
                                                                                     }
                                                                                 }
@@ -1875,11 +1875,11 @@ public class Protocol {
                                                                                         local1449 = local6565 ? 17 : 2;
                                                                                     }
                                                                                     if (local1409 == 2) {
-                                                                                        Static662.method8625("<img=1>" + local7724.method1422(), "<img=1>" + local7724.method1424(false), local996, local1427, (String) null, 0, local7724.aString8, local1449);
+                                                                                        Static662.method8625("<img=1>" + local7724.method1422(), "<img=1>" + local7724.method1424(false), local996, local1427, (String) null, 0, local7724.name1, local1449);
                                                                                     } else if (local1409 == 1) {
-                                                                                        Static662.method8625("<img=0>" + local7724.method1422(), "<img=0>" + local7724.method1424(false), local996, local1427, (String) null, 0, local7724.aString8, local1449);
+                                                                                        Static662.method8625("<img=0>" + local7724.method1422(), "<img=0>" + local7724.method1424(false), local996, local1427, (String) null, 0, local7724.name1, local1449);
                                                                                     } else {
-                                                                                        Static662.method8625(local7724.method1422(), local7724.method1424(false), local996, local1427, (String) null, 0, local7724.aString8, local1449);
+                                                                                        Static662.method8625(local7724.method1422(), local7724.method1424(false), local996, local1427, (String) null, 0, local7724.name1, local1449);
                                                                                     }
                                                                                 }
                                                                             }
@@ -2062,7 +2062,7 @@ public class Protocol {
                                                                                 local8611[local2098].anInt6148 = local11.g2();
                                                                                 local8611[local2098].aByte99 = local11.g1b();
                                                                                 local8611[local2098].aString65 = local11.gjstr();
-                                                                                if (local8611[local2098].aString66.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9)) {
+                                                                                if (local8611[local2098].aString66.equals(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2)) {
                                                                                     Static682.aByte142 = local8611[local2098].aByte99;
                                                                                 }
                                                                             }

--- a/client/src/main/java/Static104.java
+++ b/client/src/main/java/Static104.java
@@ -23,7 +23,7 @@ public final class Static104 {
 		@Pc(39) int[] local39 = Static664.method8652(local6);
 		@Pc(43) int local43 = local6.buffer.pos;
 		local6.buffer.pjstr(arg0);
-		local6.buffer.p1(Static51.anInt1052);
+		local6.buffer.p1(Static51.clientLanguageId);
 		local6.buffer.pos += 7;
 		local6.buffer.tinyenc(local39, local43, local6.buffer.pos);
 		local6.buffer.psize2(local6.buffer.pos - local28);

--- a/client/src/main/java/Static147.java
+++ b/client/src/main/java/Static147.java
@@ -104,7 +104,7 @@ public final class Static147 {
 					}
 				} else {
 					if (Static501.aBoolean576) {
-						Static416.method5707(false, -1, 0L, local140, local142, LocalizedText.FACE_HERE.get(Static51.anInt1052), 11, true, -1, "", (long) (local142 | local140 << 0), true);
+						Static416.method5707(false, -1, 0L, local140, local142, LocalizedText.FACE_HERE.get(Static51.clientLanguageId), 11, true, -1, "", (long) (local142 | local140 << 0), true);
 					}
 					Static416.method5707(false, -1, 0L, local140, local142, Static331.aString52, 58, true, Static331.anInt5439, "", (long) (local142 | local140 << 0), true);
 				}

--- a/client/src/main/java/Static149.java
+++ b/client/src/main/java/Static149.java
@@ -34,7 +34,7 @@ public final class Static149 {
 		@Pc(23) int local23 = local7 + Static84.anInt1775;
 		@Pc(25) int local25 = Static682.anInt10295;
 		@Pc(29) int local29 = Static407.anInt6288 - 3;
-		Static87.method1693(Static682.anInt10295, Static407.anInt6288, LocalizedText.CHOOSE_OPTION.get(Static51.anInt1052), arg0, local7 + Static84.anInt1775, Static71.anInt1576 - -local5);
+		Static87.method1693(Static682.anInt10295, Static407.anInt6288, LocalizedText.CHOOSE_OPTION.get(Static51.clientLanguageId), arg0, local7 + Static84.anInt1775, Static71.anInt1576 - -local5);
 		@Pc(55) int local55 = Static189.aMouse1.method8853() + local5;
 		@Pc(66) int local66 = local7 + Static189.aMouse1.method8854();
 		@Pc(70) int local70;

--- a/client/src/main/java/Static159.java
+++ b/client/src/main/java/Static159.java
@@ -33,7 +33,7 @@ public final class Static159 {
 			local9 = Static422.method5771();
 		}
 		Static97.method1905(Static84.anInt1775 + local9, Static71.anInt1576 - -local7, Static407.anInt6288, arg0, Static682.anInt10295);
-		Static180.aClass14_3.method8829(Static71.anInt1576 + local7 + 3, Static84.anInt1775 - (-local9 + -14), LocalizedText.CHOOSE_OPTION.get(Static51.anInt1052), -1, -10660793);
+		Static180.aClass14_3.method8829(Static71.anInt1576 + local7 + 3, Static84.anInt1775 - (-local9 + -14), LocalizedText.CHOOSE_OPTION.get(Static51.clientLanguageId), -1, -10660793);
 		@Pc(69) int local69 = Static189.aMouse1.method8853() + local7;
 		@Pc(76) int local76 = Static189.aMouse1.method8854() + local9;
 		@Pc(80) int local80;

--- a/client/src/main/java/Static161.java
+++ b/client/src/main/java/Static161.java
@@ -159,9 +159,9 @@ public final class Static161 {
 			@Pc(574) String local574 = arg2.gjstr();
 			if (local574.charAt(0) == '~') {
 				local574 = local574.substring(1);
-				Static44.method1072(local574, arg0.method1424(false), 0, arg0.aString8, arg0.method1422(), 2);
+				Static44.method1072(local574, arg0.method1424(false), 0, arg0.name1, arg0.method1422(), 2);
 			} else if (arg0 == Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2) {
-				Static44.method1072(local574, arg0.method1424(false), 0, arg0.aString8, arg0.method1422(), 2);
+				Static44.method1072(local574, arg0.method1424(false), 0, arg0.name1, arg0.method1422(), 2);
 			}
 			arg0.method1413(0, 0, local574);
 		}

--- a/client/src/main/java/Static229.java
+++ b/client/src/main/java/Static229.java
@@ -9,7 +9,7 @@ public final class Static229 {
 	public static void method3368() {
 		if (Static473.aClass140_22 != null) {
 			Static449.aClass364_1 = new Class364();
-			Static449.aClass364_1.method8374(Static473.aClass140_22.anInt3271, Static473.aClass140_22.aLocalizedText_63.get(Static51.anInt1052), Static473.aClass140_22, Static72.aLong52);
+			Static449.aClass364_1.method8374(Static473.aClass140_22.anInt3271, Static473.aClass140_22.aLocalizedText_63.get(Static51.clientLanguageId), Static473.aClass140_22, Static72.aLong52);
 			Static242.aThread1 = new Thread(Static449.aClass364_1, "");
 			Static242.aThread1.start();
 		}

--- a/client/src/main/java/Static231.java
+++ b/client/src/main/java/Static231.java
@@ -165,7 +165,7 @@ public final class Static231 {
 				return;
 			}
 		} catch (@Pc(323) Exception local323) {
-			Static79.method1579(LocalizedText.ERROR_EXECUTING.get(Static51.anInt1052));
+			Static79.method1579(LocalizedText.ERROR_EXECUTING.get(Static51.clientLanguageId));
 			return;
 		}
 		if (ModeWhere.LIVE != Static2.aModeWhere1 || Static608.anInt9290 >= 2) {
@@ -805,12 +805,12 @@ public final class Static231 {
 					return;
 				}
 			} catch (@Pc(2894) Exception local2894) {
-				Static79.method1579(LocalizedText.ERROR_EXECUTING.get(Static51.anInt1052));
+				Static79.method1579(LocalizedText.ERROR_EXECUTING.get(Static51.clientLanguageId));
 				return;
 			}
 		}
 		if (Static283.gameState != 11) {
-			Static79.method1579(LocalizedText.UNKNOWN_COMMAND.get(Static51.anInt1052) + arg2);
+			Static79.method1579(LocalizedText.UNKNOWN_COMMAND.get(Static51.clientLanguageId) + arg2);
 		}
 	}
 
@@ -820,7 +820,7 @@ public final class Static231 {
 			return;
 		}
 		if (Static436.anInt3849 >= 100) {
-			Static67.method6098(LocalizedText.IGNORE_FULL.get(Static51.anInt1052));
+			Static67.method6098(LocalizedText.IGNORE_FULL.get(Static51.clientLanguageId));
 			return;
 		}
 		@Pc(27) String local27 = Static390.method5492(arg1);
@@ -831,13 +831,13 @@ public final class Static231 {
 		for (@Pc(33) int local33 = 0; local33 < Static436.anInt3849; local33++) {
 			@Pc(40) String local40 = Static390.method5492(Static632.aStringArray44[local33]);
 			if (local40 != null && local40.equals(local27)) {
-				Static67.method6098(arg1 + LocalizedText.IGNORE_ALREADY_ADDED.get(Static51.anInt1052));
+				Static67.method6098(arg1 + LocalizedText.IGNORE_ALREADY_ADDED.get(Static51.clientLanguageId));
 				return;
 			}
 			if (Static10.aStringArray1[local33] != null) {
 				local76 = Static390.method5492(Static10.aStringArray1[local33]);
 				if (local76 != null && local76.equals(local27)) {
-					Static67.method6098(arg1 + LocalizedText.IGNORE_ALREADY_ADDED.get(Static51.anInt1052));
+					Static67.method6098(arg1 + LocalizedText.IGNORE_ALREADY_ADDED.get(Static51.clientLanguageId));
 					return;
 				}
 			}
@@ -845,19 +845,19 @@ public final class Static231 {
 		for (@Pc(106) int local106 = 0; local106 < Static327.anInt5392; local106++) {
 			local76 = Static390.method5492(Static330.aStringArray25[local106]);
 			if (local76 != null && local76.equals(local27)) {
-				Static67.method6098(LocalizedText.FRIEND_REMOVE_PRE.get(Static51.anInt1052) + arg1 + LocalizedText.FRIEND_REMOVE_POST.get(Static51.anInt1052));
+				Static67.method6098(LocalizedText.FRIEND_REMOVE_PRE.get(Static51.clientLanguageId) + arg1 + LocalizedText.FRIEND_REMOVE_POST.get(Static51.clientLanguageId));
 				return;
 			}
 			if (Static572.aStringArray42[local106] != null) {
 				@Pc(154) String local154 = Static390.method5492(Static572.aStringArray42[local106]);
 				if (local154 != null && local154.equals(local27)) {
-					Static67.method6098(LocalizedText.FRIEND_REMOVE_PRE.get(Static51.anInt1052) + arg1 + LocalizedText.FRIEND_REMOVE_POST.get(Static51.anInt1052));
+					Static67.method6098(LocalizedText.FRIEND_REMOVE_PRE.get(Static51.clientLanguageId) + arg1 + LocalizedText.FRIEND_REMOVE_POST.get(Static51.clientLanguageId));
 					return;
 				}
 			}
 		}
-		if (Static390.method5492(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9).equals(local27)) {
-			Static67.method6098(LocalizedText.IGNORE_CANNOT_ADD_SELF.get(Static51.anInt1052));
+		if (Static390.method5492(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2).equals(local27)) {
+			Static67.method6098(LocalizedText.IGNORE_CANNOT_ADD_SELF.get(Static51.clientLanguageId));
 			return;
 		}
 		@Pc(216) Connection local216 = Connection.getActiveConnection();

--- a/client/src/main/java/Static242.java
+++ b/client/src/main/java/Static242.java
@@ -36,7 +36,7 @@ public final class Static242 {
 
 	@OriginalMember(owner = "client!hj", name = "c", descriptor = "(I)V")
 	public static void method3502() {
-		Static525.aClass2_Sub2_Sub16_12 = new SecondaryLinkable_Sub16(LocalizedText.CANCEL.get(Static51.anInt1052), "", Static442.anInt6699, 1012, -1, 0L, 0, 0, true, false, 0L, true);
+		Static525.aClass2_Sub2_Sub16_12 = new SecondaryLinkable_Sub16(LocalizedText.CANCEL.get(Static51.clientLanguageId), "", Static442.anInt6699, 1012, -1, 0L, 0, 0, true, false, 0L, true);
 	}
 
 	@OriginalMember(owner = "client!hj", name = "a", descriptor = "(IZ)I")
@@ -60,7 +60,7 @@ public final class Static242 {
 		@Pc(9) boolean local9 = false;
 		for (@Pc(19) int local19 = 0; local19 < local5; local19++) {
 			@Pc(26) Player local26 = Static621.aClass8_Sub2_Sub1_Sub2_Sub1Array3[local7[local19]];
-			if (local26 != null && Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 != local26 && local26.aString9 != null && local26.aString9.equalsIgnoreCase(arg0)) {
+			if (local26 != null && Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 != local26 && local26.name2 != null && local26.name2.equalsIgnoreCase(arg0)) {
 				@Pc(47) ClientProt local47 = null;
 				if (arg1 == 1) {
 					local47 = Static424.aClientProt79;
@@ -86,7 +86,7 @@ public final class Static242 {
 			}
 		}
 		if (!local9) {
-			Static67.method6098(LocalizedText.FRIEND_UNABLE_TO_FIND.get(Static51.anInt1052) + arg0);
+			Static67.method6098(LocalizedText.FRIEND_UNABLE_TO_FIND.get(Static51.clientLanguageId) + arg0);
 		}
 	}
 }

--- a/client/src/main/java/Static254.java
+++ b/client/src/main/java/Static254.java
@@ -100,7 +100,7 @@ public final class Static254 {
 		Static218.method3187();
 		Static273.aBoolean339 = true;
 		Static637.aShortArray132 = Static419.aShortArray96 = Static553.aShortArray112 = Static238.aShortArray62 = new short[256];
-		Static331.aString52 = LocalizedText.WALK_HERE.get(Static51.anInt1052);
+		Static331.aString52 = LocalizedText.WALK_HERE.get(Static51.clientLanguageId);
 		Static400.aClass2_Sub34_28.method5104(Static400.aClass2_Sub34_28.aPreference_Sub4_1.method2143(), Static400.aClass2_Sub34_28.aPreference_Sub4_2);
 		Static400.aClass2_Sub34_28.method5104(Static400.aClass2_Sub34_28.aPreference_Sub19_1.method5960(), Static400.aClass2_Sub34_28.aPreference_Sub19_2);
 		Static334.anInt5456 = 0;

--- a/client/src/main/java/Static279.java
+++ b/client/src/main/java/Static279.java
@@ -21,7 +21,7 @@ public final class Static279 {
 		for (@Pc(35) int local35 = 0; local35 < Static393.aStringArray32.length; local35++) {
 			Static393.aStringArray32[local35] = "";
 		}
-		Static79.method1579(LocalizedText.DEVELOPER_HELP.get(Static51.anInt1052));
+		Static79.method1579(LocalizedText.DEVELOPER_HELP.get(Static51.clientLanguageId));
 	}
 
 	@OriginalMember(owner = "client!io", name = "a", descriptor = "(III)Z")

--- a/client/src/main/java/Static28.java
+++ b/client/src/main/java/Static28.java
@@ -110,14 +110,14 @@ public final class Static28 {
 				local585 = local541.anInt10694 / 128 - local93 / 128;
 				@Pc(587) boolean local587 = false;
 				for (local589 = 0; local589 < Static327.anInt5392; local589++) {
-					if (local541.aString9.equals(Static330.aStringArray25[local589]) && Static371.anIntArray455[local589] != 0) {
+					if (local541.name2.equals(Static330.aStringArray25[local589]) && Static371.anIntArray455[local589] != 0) {
 						local587 = true;
 						break;
 					}
 				}
 				@Pc(620) boolean local620 = false;
 				for (local622 = 0; local622 < Static706.anInt10633; local622++) {
-					if (local541.aString9.equals(Static87.aClass241Array1[local622].aString66)) {
+					if (local541.name2.equals(Static87.aClass241Array1[local622].aString66)) {
 						local620 = true;
 						break;
 					}

--- a/client/src/main/java/Static294.java
+++ b/client/src/main/java/Static294.java
@@ -187,7 +187,7 @@ public final class Static294 {
 		}
 		if (Static426.aBoolean72) {
 			Static163.aClass19_17.method7971(local155, local161, local159, local153, -16777216);
-			Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052), false, Static694.aClass381_13, Static437.aClass14_9);
+			Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId), false, Static694.aClass381_13, Static437.aClass14_9);
 		}
 		Static501.method6716(false);
 	}

--- a/client/src/main/java/Static32.java
+++ b/client/src/main/java/Static32.java
@@ -43,6 +43,6 @@ public final class Static32 {
 
 	@OriginalMember(owner = "client!bba", name = "a", descriptor = "(IZZ)V")
 	public static void method880(@OriginalArg(0) int arg0, @OriginalArg(2) boolean arg1) {
-		Static667.method8695(arg1, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052), arg0);
+		Static667.method8695(arg1, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId), arg0);
 	}
 }

--- a/client/src/main/java/Static360.java
+++ b/client/src/main/java/Static360.java
@@ -98,9 +98,9 @@ public final class Static360 {
 			local8 = local8.substring(0, local13) + "," + local8.substring(local13);
 		}
 		if (local8.length() > 9) {
-			return " <col=00ff80>" + local8.substring(0, local8.length() - 8) + LocalizedText.LETTER_M.get(Static51.anInt1052) + " (" + local8 + ")</col>";
+			return " <col=00ff80>" + local8.substring(0, local8.length() - 8) + LocalizedText.LETTER_M.get(Static51.clientLanguageId) + " (" + local8 + ")</col>";
 		} else if (local8.length() > 6) {
-			return " <col=ffffff>" + local8.substring(0, local8.length() - 4) + LocalizedText.LETTER_K.get(Static51.anInt1052) + " (" + local8 + ")</col>";
+			return " <col=ffffff>" + local8.substring(0, local8.length() - 4) + LocalizedText.LETTER_K.get(Static51.clientLanguageId) + " (" + local8 + ")</col>";
 		} else {
 			return " <col=ffff00>" + local8 + "</col>";
 		}

--- a/client/src/main/java/Static362.java
+++ b/client/src/main/java/Static362.java
@@ -26,6 +26,6 @@ public final class Static362 {
 				return true;
 			}
 		}
-		return arg1.equalsIgnoreCase(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9);
+		return arg1.equalsIgnoreCase(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2);
 	}
 }

--- a/client/src/main/java/Static363.java
+++ b/client/src/main/java/Static363.java
@@ -53,14 +53,14 @@ public final class Static363 {
 			return 1;
 		}
 		if (arg1 != Static400.aClass2_Sub34_28.aPreference_Sub29_1.method7915()) {
-			Static667.method8695(true, LocalizedText.PROFILING.get(Static51.anInt1052), arg1);
+			Static667.method8695(true, LocalizedText.PROFILING.get(Static51.clientLanguageId), arg1);
 			if (arg1 != Static400.aClass2_Sub34_28.aPreference_Sub29_1.method7915()) {
 				return -1;
 			}
 		}
 		try {
 			@Pc(43) Dimension local43 = Static434.aCanvas7.getSize();
-			Static694.method9028(Static163.aClass19_17, LocalizedText.PROFILING.get(Static51.anInt1052), true, Static694.aClass381_13, Static437.aClass14_9);
+			Static694.method9028(Static163.aClass19_17, LocalizedText.PROFILING.get(Static51.clientLanguageId), true, Static694.aClass381_13, Static437.aClass14_9);
 			@Pc(67) Class88 local67 = Static121.method2201(Static65.aClass3_1.anInt81, client.models);
 			@Pc(70) long local70 = Static588.method7715();
 			Static163.aClass19_17.la();

--- a/client/src/main/java/Static364.java
+++ b/client/src/main/java/Static364.java
@@ -121,13 +121,13 @@ public final class Static364 {
 					@Pc(229) Packet local229 = Static570.method7552();
 					local229.p1(Static129.anInt2409);
 					local229.p2((int) (Math.random() * 9.9999999E7D));
-					local229.p1(Static51.anInt1052);
+					local229.p1(Static51.clientLanguageId);
 					local229.p4(Static323.anInt5121);
 					for (local250 = 0; local250 < 6; local250++) {
 						local229.p4((int) (Math.random() * 9.9999999E7D));
 					}
 					local229.p8(Static571.aLong269);
-					local229.p1(Static392.aModeGame4.id);
+					local229.p1(Static392.clientModeGame.id);
 					local229.p1((int) (Math.random() * 9.9999999E7D));
 					local229.rsaenc(ClientConfig.aBigInteger2, ClientConfig.aBigInteger1);
 					local186.buffer.pdata(local229.data, 0, local229.pos);
@@ -276,8 +276,8 @@ public final class Static364 {
 						local646 = local618.pos;
 						local618.pjstr(Static449.aString75);
 					}
-					local618.p1(Static392.aModeGame4.id);
-					local618.p1(Static51.anInt1052);
+					local618.p1(Static392.clientModeGame.id);
+					local618.p1(Static51.clientLanguageId);
 					Static176.method6690(local618);
 					local618.pjstr(Static150.aString26);
 					local618.p4(Static323.anInt5121);
@@ -439,7 +439,7 @@ public final class Static364 {
 						Static626.anInt9473 = local1435.g2();
 						Static636.anInt9527 = local1435.g2();
 						Static420.aBoolean479 = local1435.g1() == 1;
-						Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString8 = Static515.aString96 = local1435.gjstr2();
+						Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name1 = Static515.aString96 = local1435.gjstr2();
 						Static639.anInt9571 = local1435.g1();
 						Static438.anInt6640 = local1435.g4();
 						Static587.aBoolean663 = local1435.g1() == 1;

--- a/client/src/main/java/Static392.java
+++ b/client/src/main/java/Static392.java
@@ -9,7 +9,7 @@ public final class Static392 {
 	public static int anInt6142;
 
 	@OriginalMember(owner = "client!mf", name = "c", descriptor = "Lclient!ul;")
-	public static ModeGame aModeGame4 = null;
+	public static ModeGame clientModeGame = null;
 
 	@OriginalMember(owner = "client!mf", name = "k", descriptor = "I")
 	public static int anInt6143 = 0;

--- a/client/src/main/java/Static414.java
+++ b/client/src/main/java/Static414.java
@@ -21,7 +21,7 @@ public final class Static414 {
 				@Pc(63) boolean local63 = true;
 				if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1471 != -1 && arg1.anInt1471 != -1) {
 					@Pc(91) int local91 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1471 < arg1.anInt1471 ? Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1471 : arg1.anInt1471;
-					@Pc(98) int local98 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444 - arg1.anInt1444;
+					@Pc(98) int local98 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2 - arg1.combatLevel2;
 					if (local98 < 0) {
 						local98 = -local98;
 					}
@@ -29,16 +29,16 @@ public final class Static414 {
 						local63 = false;
 					}
 				}
-				@Pc(129) String local129 = ModeGame.GAME_STELLARDAWN == Static392.aModeGame4 ? LocalizedText.RATING.get(Static51.anInt1052) : LocalizedText.LEVEL.get(Static51.anInt1052);
-				if (arg1.anInt1444 >= arg1.anInt1437) {
-					local177 = arg1.method1424(false) + (local63 ? Static693.method9009(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444, arg1.anInt1444) : "<col=ffffff>") + " (" + local129 + arg1.anInt1444 + ")";
+				@Pc(129) String local129 = ModeGame.GAME_STELLARDAWN == Static392.clientModeGame ? LocalizedText.RATING.get(Static51.clientLanguageId) : LocalizedText.LEVEL.get(Static51.clientLanguageId);
+				if (arg1.combatLevel2 >= arg1.combatLevel1) {
+					local177 = arg1.method1424(false) + (local63 ? Static693.levelDifferenceColor(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2, arg1.combatLevel2) : "<col=ffffff>") + " (" + local129 + arg1.combatLevel2 + ")";
 				} else {
-					local177 = arg1.method1424(false) + (local63 ? Static693.method9009(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444, arg1.anInt1444) : "<col=ffffff>") + " (" + local129 + arg1.anInt1444 + "+" + (arg1.anInt1437 - arg1.anInt1444) + ")";
+					local177 = arg1.method1424(false) + (local63 ? Static693.levelDifferenceColor(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2, arg1.combatLevel2) : "<col=ffffff>") + " (" + local129 + arg1.combatLevel2 + "+" + (arg1.combatLevel1 - arg1.combatLevel2) + ")";
 				}
 			} else if (arg1.anInt1436 == -1) {
 				local177 = arg1.method1424(false);
 			} else {
-				local177 = arg1.method1424(false) + " (" + LocalizedText.SKILL.get(Static51.anInt1052) + arg1.anInt1436 + ")";
+				local177 = arg1.method1424(false) + " (" + LocalizedText.SKILL.get(Static51.clientLanguageId) + arg1.anInt1436 + ")";
 			}
 			if (Static156.aBoolean223 && !arg0 && (Static717.anInt10822 & 0x8) != 0) {
 				Static416.method5707(false, -1, (long) arg1.anInt10740, 0, 0, Static153.aString27, 44, true, Static369.anInt4263, Static128.aString108 + " -> <col=ffffff>" + local177, (long) arg1.anInt10740, false);
@@ -49,8 +49,8 @@ public final class Static414 {
 				for (@Pc(318) int local318 = 7; local318 >= 0; local318--) {
 					if (Static297.aStringArray24[local318] != null) {
 						@Pc(325) short local325 = 0;
-						if (Static392.aModeGame4 == ModeGame.GAME_RUNESCAPE && Static297.aStringArray24[local318].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.anInt1052))) {
-							if (Static324.aBoolean388 && Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444 < arg1.anInt1444) {
+						if (Static392.clientModeGame == ModeGame.GAME_RUNESCAPE && Static297.aStringArray24[local318].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.clientLanguageId))) {
+							if (Static324.aBoolean388 && Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2 < arg1.combatLevel2) {
 								local325 = 2000;
 							}
 							if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1433 == 0 || arg1.anInt1433 == 0) {
@@ -80,13 +80,13 @@ public final class Static414 {
 				}
 			}
 		} else if (Static156.aBoolean223 && (Static717.anInt10822 & 0x10) != 0) {
-			Static416.method5707(false, -1, 0L, 0, 0, Static153.aString27, 4, true, Static369.anInt4263, Static128.aString108 + " -> <col=ffffff>" + LocalizedText.SELF.get(Static51.anInt1052), (long) arg1.anInt10740, false);
+			Static416.method5707(false, -1, 0L, 0, 0, Static153.aString27, 4, true, Static369.anInt4263, Static128.aString108 + " -> <col=ffffff>" + LocalizedText.SELF.get(Static51.clientLanguageId), (long) arg1.anInt10740, false);
 		}
 	}
 
 	@OriginalMember(owner = "client!nba", name = "a", descriptor = "(III)V")
 	public static void method5697(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1) {
-		if (Static392.aModeGame4 == ModeGame.GAME_STELLARDAWN) {
+		if (Static392.clientModeGame == ModeGame.GAME_STELLARDAWN) {
 			if (!Static147.method2419(0, arg0, 1, false, arg1, 0, -2, 1)) {
 				Static147.method2419(0, arg0, 1, false, arg1, 0, -3, 1);
 			}

--- a/client/src/main/java/Static420.java
+++ b/client/src/main/java/Static420.java
@@ -45,7 +45,7 @@ public final class Static420 {
 			return;
 		}
 		if (arg0.aString42 == null) {
-			Static416.method5707(false, arg0.anInt3760, 0L, arg0.anInt3741, arg0.anInt3812, LocalizedText.CONTINUE.get(Static51.anInt1052), 10, true, -1, "", (long) (arg0.anInt3812 | arg0.anInt3741 << 0), false);
+			Static416.method5707(false, arg0.anInt3760, 0L, arg0.anInt3741, arg0.anInt3812, LocalizedText.CONTINUE.get(Static51.clientLanguageId), 10, true, -1, "", (long) (arg0.anInt3812 | arg0.anInt3741 << 0), false);
 		} else {
 			Static416.method5707(false, arg0.anInt3760, 0L, arg0.anInt3741, arg0.anInt3812, arg0.aString42, 10, true, -1, "", (long) (arg0.anInt3812 | arg0.anInt3741 << 0), false);
 		}

--- a/client/src/main/java/Static430.java
+++ b/client/src/main/java/Static430.java
@@ -44,7 +44,7 @@ public final class Static430 {
 		if (Static150.aString26 != null) {
 			local88 = "/p=" + Static150.aString26;
 		}
-		@Pc(152) String local152 = "http://" + arg1 + local73 + "/l=" + Static51.anInt1052 + "/a=" + Static323.anInt5121 + local88 + "/j" + (Static98.aBoolean191 ? "1" : "0") + ",o" + (Static464.aBoolean533 ? "1" : "0") + ",a2";
+		@Pc(152) String local152 = "http://" + arg1 + local73 + "/l=" + Static51.clientLanguageId + "/a=" + Static323.anInt5121 + local88 + "/j" + (Static98.aBoolean191 ? "1" : "0") + ",o" + (Static464.aBoolean533 ? "1" : "0") + ",a2";
 		try {
 			Static295.aClient1.getAppletContext().showDocument(new URL(local152), "_self");
 			return true;

--- a/client/src/main/java/Static472.java
+++ b/client/src/main/java/Static472.java
@@ -81,7 +81,7 @@ public final class Static472 {
 		if (local4 == null) {
 			throw new RuntimeException("sr-c113");
 		}
-		@Pc(29) Integer local29 = aClass164_7.method3495(Static392.aModeGame4.id << 16 | local4.anInt8745, local4.anInt8746, local4.anInt8742);
+		@Pc(29) Integer local29 = aClass164_7.method3495(Static392.clientModeGame.id << 16 | local4.anInt8745, local4.anInt8746, local4.anInt8742);
 		return local29 == null ? 0 : local29;
 	}
 
@@ -91,7 +91,7 @@ public final class Static472 {
 		if (local4 == null) {
 			throw new RuntimeException("sr-c112");
 		}
-		@Pc(24) Integer local24 = aClass164_7.method3490(Static392.aModeGame4.id << 16 | arg0);
+		@Pc(24) Integer local24 = aClass164_7.method3490(Static392.clientModeGame.id << 16 | arg0);
 		if (local24 == null) {
 			return local4.aChar7 == 'i' || local4.aChar7 == '1' ? 0 : -1;
 		} else {
@@ -101,7 +101,7 @@ public final class Static472 {
 
 	@OriginalMember(owner = "client!ou", name = "c", descriptor = "(I)J")
 	private static long method6413(@OriginalArg(0) int arg0) {
-		@Pc(9) Long local9 = aClass164_7.method3478(Static392.aModeGame4.id << 16 | arg0);
+		@Pc(9) Long local9 = aClass164_7.method3478(Static392.clientModeGame.id << 16 | arg0);
 		return local9 == null ? -1L : local9;
 	}
 
@@ -1709,7 +1709,7 @@ public final class Static472 {
 										return;
 									}
 									if (arg0 == 3326) {
-										anIntArray578[anInt7142++] = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444;
+										anIntArray578[anInt7142++] = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2;
 										return;
 									}
 									if (arg0 == 3327) {
@@ -1744,7 +1744,7 @@ public final class Static472 {
 										return;
 									}
 									if (arg0 == 3335) {
-										anIntArray578[anInt7142++] = Static51.anInt1052;
+										anIntArray578[anInt7142++] = Static51.clientLanguageId;
 										return;
 									}
 									if (arg0 == 3336) {
@@ -2159,7 +2159,7 @@ public final class Static472 {
 										}
 										if (arg0 == 3624) {
 											local15 = anIntArray578[--anInt7142];
-											if (Static87.aClass241Array1 != null && local15 < Static706.anInt10633 && Static87.aClass241Array1[local15].aString66.equalsIgnoreCase(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9)) {
+											if (Static87.aClass241Array1 != null && local15 < Static706.anInt10633 && Static87.aClass241Array1[local15].aString66.equalsIgnoreCase(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2)) {
 												anIntArray578[anInt7142++] = 1;
 												return;
 											}
@@ -2652,7 +2652,7 @@ public final class Static472 {
 												return;
 											}
 											if (arg0 == 4104) {
-												aStringArray37[anInt7139++] = Static522.method6994(Static51.anInt1052, Static38.method1003(anIntArray578[--anInt7142]));
+												aStringArray37[anInt7139++] = Static522.method6994(Static51.clientLanguageId, Static38.method1003(anIntArray578[--anInt7142]));
 												return;
 											}
 											if (arg0 == 4105) {
@@ -2673,7 +2673,7 @@ public final class Static472 {
 											}
 											if (arg0 == 4107) {
 												anInt7139 -= 2;
-												anIntArray578[anInt7142++] = Static540.method6538(aStringArray37[anInt7139 + 1], Static51.anInt1052, aStringArray37[anInt7139]);
+												anIntArray578[anInt7142++] = Static540.method6538(aStringArray37[anInt7139 + 1], Static51.clientLanguageId, aStringArray37[anInt7139]);
 												return;
 											}
 											@Pc(10482) Class381 local10482;
@@ -2803,7 +2803,7 @@ public final class Static472 {
 											if (arg0 == 4124) {
 												local575 = anIntArray578[--anInt7142] != 0;
 												local21 = anIntArray578[--anInt7142];
-												aStringArray37[anInt7139++] = Static573.method7571(Static51.anInt1052, local575, (long) local21, 0);
+												aStringArray37[anInt7139++] = Static573.method7571(Static51.clientLanguageId, local575, (long) local21, 0);
 												return;
 											}
 											if (arg0 == 4125) {
@@ -2814,7 +2814,7 @@ public final class Static472 {
 												return;
 											}
 											if (arg0 == 4126) {
-												aStringArray37[anInt7139++] = Static647.method8474((long) anIntArray578[--anInt7142] * 60000L, Static51.anInt1052) + " UTC";
+												aStringArray37[anInt7139++] = Static647.method8474((long) anIntArray578[--anInt7142] * 60000L, Static51.clientLanguageId) + " UTC";
 												return;
 											}
 											if (arg0 == 4127) {
@@ -3679,7 +3679,7 @@ public final class Static472 {
 				return;
 			}
 			if (arg0 == 5015) {
-				if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == null || Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString8 == null) {
+				if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == null || Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name1 == null) {
 					local95 = "";
 				} else {
 					local95 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.method1424(false);
@@ -3716,7 +3716,7 @@ public final class Static472 {
 				return;
 			}
 			if (arg0 == 5020) {
-				if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == null || Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString8 == null) {
+				if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == null || Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name1 == null) {
 					local95 = "";
 				} else {
 					local95 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.method1422();
@@ -4481,13 +4481,13 @@ public final class Static472 {
 						local109 = anIntArray578[--anInt7142];
 						if (local95.length() > 0) {
 							if (Static685.aStringArray47 == null) {
-								Static685.aStringArray47 = new String[Static390.anIntArray476[Static392.aModeGame4.id]];
+								Static685.aStringArray47 = new String[Static390.anIntArray476[Static392.clientModeGame.id]];
 							}
 							Static685.aStringArray47[local109] = local95;
 						}
 						if (local101.length() > 0) {
 							if (Static377.aStringArray30 == null) {
-								Static377.aStringArray30 = new String[Static390.anIntArray476[Static392.aModeGame4.id]];
+								Static377.aStringArray30 = new String[Static390.anIntArray476[Static392.clientModeGame.id]];
 							}
 							Static377.aStringArray30[local109] = local101;
 						}
@@ -6213,7 +6213,7 @@ public final class Static472 {
 
 	@OriginalMember(owner = "client!ou", name = "e", descriptor = "(I)Ljava/lang/String;")
 	private static String method6425(@OriginalArg(0) int arg0) {
-		@Pc(9) String local9 = aClass164_7.method3484(Static392.aModeGame4.id << 16 | arg0);
+		@Pc(9) String local9 = aClass164_7.method3484(Static392.clientModeGame.id << 16 | arg0);
 		return local9 == null ? "" : local9;
 	}
 
@@ -6260,43 +6260,43 @@ public final class Static472 {
 		} else if (local18.startsWith(LocalizedText.GLOW3.get(0))) {
 			local20 = 11;
 			arg0 = arg0.substring(LocalizedText.GLOW3.get(0).length());
-		} else if (Static51.anInt1052 != 0) {
-			if (local18.startsWith(LocalizedText.YELLOW.get(Static51.anInt1052))) {
+		} else if (Static51.clientLanguageId != 0) {
+			if (local18.startsWith(LocalizedText.YELLOW.get(Static51.clientLanguageId))) {
 				local20 = 0;
-				arg0 = arg0.substring(LocalizedText.YELLOW.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.RED.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.YELLOW.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.RED.get(Static51.clientLanguageId))) {
 				local20 = 1;
-				arg0 = arg0.substring(LocalizedText.RED.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.GREEN.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.RED.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.GREEN.get(Static51.clientLanguageId))) {
 				local20 = 2;
-				arg0 = arg0.substring(LocalizedText.GREEN.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.CYAN.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.GREEN.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.CYAN.get(Static51.clientLanguageId))) {
 				local20 = 3;
-				arg0 = arg0.substring(LocalizedText.CYAN.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.PURPLE.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.CYAN.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.PURPLE.get(Static51.clientLanguageId))) {
 				local20 = 4;
-				arg0 = arg0.substring(LocalizedText.PURPLE.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.WHITE.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.PURPLE.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.WHITE.get(Static51.clientLanguageId))) {
 				local20 = 5;
-				arg0 = arg0.substring(LocalizedText.WHITE.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.FLASH1.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.WHITE.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.FLASH1.get(Static51.clientLanguageId))) {
 				local20 = 6;
-				arg0 = arg0.substring(LocalizedText.FLASH1.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.FLASH2.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.FLASH1.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.FLASH2.get(Static51.clientLanguageId))) {
 				local20 = 7;
-				arg0 = arg0.substring(LocalizedText.FLASH2.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.FLASH3.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.FLASH2.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.FLASH3.get(Static51.clientLanguageId))) {
 				local20 = 8;
-				arg0 = arg0.substring(LocalizedText.FLASH3.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.GLOW1.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.FLASH3.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.GLOW1.get(Static51.clientLanguageId))) {
 				local20 = 9;
-				arg0 = arg0.substring(LocalizedText.GLOW1.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.GLOW2.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.GLOW1.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.GLOW2.get(Static51.clientLanguageId))) {
 				local20 = 10;
-				arg0 = arg0.substring(LocalizedText.GLOW2.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.GLOW3.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.GLOW2.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.GLOW3.get(Static51.clientLanguageId))) {
 				local20 = 11;
-				arg0 = arg0.substring(LocalizedText.GLOW3.get(Static51.anInt1052).length());
+				arg0 = arg0.substring(LocalizedText.GLOW3.get(Static51.clientLanguageId).length());
 			}
 		}
 		local18 = arg0.toLowerCase();
@@ -6316,22 +6316,22 @@ public final class Static472 {
 		} else if (local18.startsWith(LocalizedText.SLIDE.get(0))) {
 			local460 = 5;
 			arg0 = arg0.substring(LocalizedText.SLIDE.get(0).length());
-		} else if (Static51.anInt1052 != 0) {
-			if (local18.startsWith(LocalizedText.WAVE.get(Static51.anInt1052))) {
+		} else if (Static51.clientLanguageId != 0) {
+			if (local18.startsWith(LocalizedText.WAVE.get(Static51.clientLanguageId))) {
 				local460 = 1;
-				arg0 = arg0.substring(LocalizedText.WAVE.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.WAVE2.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.WAVE.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.WAVE2.get(Static51.clientLanguageId))) {
 				local460 = 2;
-				arg0 = arg0.substring(LocalizedText.WAVE2.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.SHAKE.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.WAVE2.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.SHAKE.get(Static51.clientLanguageId))) {
 				local460 = 3;
-				arg0 = arg0.substring(LocalizedText.SHAKE.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.SCROLL.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.SHAKE.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.SCROLL.get(Static51.clientLanguageId))) {
 				local460 = 4;
-				arg0 = arg0.substring(LocalizedText.SCROLL.get(Static51.anInt1052).length());
-			} else if (local18.startsWith(LocalizedText.SLIDE.get(Static51.anInt1052))) {
+				arg0 = arg0.substring(LocalizedText.SCROLL.get(Static51.clientLanguageId).length());
+			} else if (local18.startsWith(LocalizedText.SLIDE.get(Static51.clientLanguageId))) {
 				local460 = 5;
-				arg0 = arg0.substring(LocalizedText.SLIDE.get(Static51.anInt1052).length());
+				arg0 = arg0.substring(LocalizedText.SLIDE.get(Static51.clientLanguageId).length());
 			}
 		}
 		@Pc(650) Connection local650 = Connection.getActiveConnection();

--- a/client/src/main/java/Static489.java
+++ b/client/src/main/java/Static489.java
@@ -186,7 +186,7 @@ public final class Static489 {
 			return;
 		}
 		if (Static213.anInt3472 != 0) {
-			Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052) + "<br>(100%)", true, Static694.aClass381_13, Static437.aClass14_9);
+			Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId) + "<br>(100%)", true, Static694.aClass381_13, Static437.aClass14_9);
 		}
 		Static557.method7331();
 		Static352.resetCache();

--- a/client/src/main/java/Static51.java
+++ b/client/src/main/java/Static51.java
@@ -11,7 +11,7 @@ public final class Static51 {
 	public static final ServerProt ServerProt30 = new ServerProt(54, -1);
 
 	@OriginalMember(owner = "client!bma", name = "c", descriptor = "I")
-	public static int anInt1052 = 0;
+	public static int clientLanguageId = 0;
 
 	@OriginalMember(owner = "client!bma", name = "b", descriptor = "I")
 	public static int anInt1053 = 0;

--- a/client/src/main/java/Static515.java
+++ b/client/src/main/java/Static515.java
@@ -53,7 +53,7 @@ public final class Static515 {
 		@Pc(152) int local152 = Static534.anInt8111 * local46 / Static30.anInt5650 + local75;
 		@Pc(166) int local166 = local48 + local84 - local144 - Static510.anInt7639 * local48 / Static30.anInt5644;
 		@Pc(168) int local168 = -1996554240;
-		if (Static392.aModeGame4 == ModeGame.GAME_STELLARDAWN) {
+		if (Static392.clientModeGame == ModeGame.GAME_STELLARDAWN) {
 			local168 = -1996488705;
 		}
 		arg1.aa(local152, local166, local138, local144, local168, 1);
@@ -92,7 +92,7 @@ public final class Static515 {
 		}
 		if (Static234.aBoolean303) {
 			@Pc(34) Linkable_Sub5 local34 = new Linkable_Sub5(arg1, new Class222_Sub1(4096, client.js5Archive36, arg1), arg2, arg0);
-			local34.aClass222_Sub1_1.method9183(Static384.aStringArray31[Static51.anInt1052]);
+			local34.aClass222_Sub1_1.method9183(Static384.aStringArray31[Static51.clientLanguageId]);
 			Static106.aHashTable11.put((long) arg1, local34);
 		} else {
 			Static635.method8380(arg1, arg0);

--- a/client/src/main/java/Static518.java
+++ b/client/src/main/java/Static518.java
@@ -15,11 +15,11 @@ public final class Static518 {
 	@OriginalMember(owner = "client!qf", name = "a", descriptor = "(Lclient!pg;B)Ljava/lang/String;")
 	public static String method9293(@OriginalArg(0) SecondaryLinkable_Sub16 arg0) {
 		if (arg0.aString88 == null || arg0.aString88.length() == 0) {
-			return arg0.aString86 == null || arg0.aString86.length() <= 0 ? arg0.aString87 : arg0.aString87 + LocalizedText.SPACE.get(Static51.anInt1052) + arg0.aString86;
+			return arg0.aString86 == null || arg0.aString86.length() <= 0 ? arg0.aString87 : arg0.aString87 + LocalizedText.SPACE.get(Static51.clientLanguageId) + arg0.aString86;
 		} else if (arg0.aString86 == null || arg0.aString86.length() <= 0) {
-			return arg0.aString87 + LocalizedText.SPACE.get(Static51.anInt1052) + arg0.aString88;
+			return arg0.aString87 + LocalizedText.SPACE.get(Static51.clientLanguageId) + arg0.aString88;
 		} else {
-			return arg0.aString87 + LocalizedText.SPACE.get(Static51.anInt1052) + arg0.aString86 + LocalizedText.SPACE.get(Static51.anInt1052) + arg0.aString88;
+			return arg0.aString87 + LocalizedText.SPACE.get(Static51.clientLanguageId) + arg0.aString86 + LocalizedText.SPACE.get(Static51.clientLanguageId) + arg0.aString88;
 		}
 	}
 }

--- a/client/src/main/java/Static523.java
+++ b/client/src/main/java/Static523.java
@@ -49,7 +49,7 @@ public final class Static523 {
 		if (Static376.anInt5921 != arg0.anInt3806) {
 			return;
 		}
-		if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9 == null) {
+		if (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2 == null) {
 			arg0.anInt3831 = 0;
 			arg0.anInt3738 = 0;
 			return;
@@ -58,7 +58,7 @@ public final class Static523 {
 		arg0.anInt3811 = (int) (Math.sin((double) Static333.anInt5455 / 40.0D) * 256.0D) & 0x7FF;
 		arg0.anInt3823 = 5;
 		arg0.anInt3831 = Static312.anInt5000;
-		arg0.anInt3738 = Static214.method3157(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9);
+		arg0.anInt3738 = Static214.method3157(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2);
 		@Pc(55) Class152 local55 = Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aClass152_10;
 		if (local55 == null) {
 			arg0.aClass152_6 = null;

--- a/client/src/main/java/Static556.java
+++ b/client/src/main/java/Static556.java
@@ -41,7 +41,7 @@ public final class Static556 {
 		}
 		@Pc(63) String local63;
 		if (Static156.aBoolean223 && Static594.anInt8777 < 2) {
-			local63 = Static153.aString27 + LocalizedText.SPACE.get(Static51.anInt1052) + Static128.aString108 + " ->";
+			local63 = Static153.aString27 + LocalizedText.SPACE.get(Static51.clientLanguageId) + Static128.aString108 + " ->";
 		} else if (Static209.shiftClickEnabled && Static334.aKeyboard1.method8479(81) && Static594.anInt8777 > 2) {
 			local63 = Static518.method9293(Static470.aClass2_Sub2_Sub16_10);
 		} else {
@@ -81,7 +81,7 @@ public final class Static556 {
 			}
 		}
 		if (Static594.anInt8777 > 2) {
-			local63 = local63 + "<col=ffffff> / " + (Static594.anInt8777 - 2) + LocalizedText.MORE_OPTIONS.get(Static51.anInt1052);
+			local63 = local63 + "<col=ffffff> / " + (Static594.anInt8777 - 2) + LocalizedText.MORE_OPTIONS.get(Static51.clientLanguageId);
 		}
 		if (Static605.aComponent15 != null) {
 			@Pc(232) Class14 local232 = Static605.aComponent15.method3403(arg0);
@@ -90,7 +90,7 @@ public final class Static556 {
 			}
 			local232.method8836(Static329.anIntArray163, Static605.aComponent15.anInt3818, Static605.aComponent15.anInt3802, Static460.anIntArray554, Static605.aComponent15.anInt3779, Static605.aComponent15.anInt3746, Static493.aRandom1, local63, Static366.anInt5852, Static605.aComponent15.anInt3798, Static186.aSoftwareIndexedSpriteArray5, Static178.anInt2947, Static157.anInt2777, Static605.aComponent15.anInt3814);
 			Static585.method7670(Static329.anIntArray163[2], Static329.anIntArray163[0], Static329.anIntArray163[3], Static329.anIntArray163[1]);
-		} else if (Static71.aComponent2 != null && Static392.aModeGame4 == ModeGame.GAME_RUNESCAPE) {
+		} else if (Static71.aComponent2 != null && Static392.clientModeGame == ModeGame.GAME_RUNESCAPE) {
 			@Pc(299) int local299 = Static180.aClass14_3.method8816(Static186.aSoftwareIndexedSpriteArray5, Static178.anInt2947, Static192.anInt3123 + 16, local63, Static460.anIntArray554, Static493.aRandom1, Static725.anInt10936 + 4);
 			Static585.method7670(local299 + Static42.aClass381_4.method8744(local63), Static725.anInt10936 - -4, 16, Static192.anInt3123);
 		}

--- a/client/src/main/java/Static57.java
+++ b/client/src/main/java/Static57.java
@@ -86,7 +86,7 @@ public final class Static57 {
 		@Pc(26) int[] local26 = Static210.anIntArray280;
 		for (@Pc(28) int local28 = 0; local28 < local24; local28++) {
 			@Pc(35) Player local35 = Static621.aClass8_Sub2_Sub1_Sub2_Sub1Array3[local26[local28]];
-			if (local35.aString9 != null && local35.aString9.equalsIgnoreCase(arg0) && (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == local35 && (Static717.anInt10822 & 0x10) != 0 || (Static717.anInt10822 & 0x8) != 0)) {
+			if (local35.name2 != null && local35.name2.equalsIgnoreCase(arg0) && (Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2 == local35 && (Static717.anInt10822 & 0x10) != 0 || (Static717.anInt10822 & 0x8) != 0)) {
 				@Pc(75) OutboundPacket local75 = OutboundPacket.create(Static664.aClientProt115, Connection.gameConnection.random);
 				local75.buffer.ip2(local26[local28]);
 				local75.buffer.p4_alt1(Static450.anInt6819);
@@ -100,7 +100,7 @@ public final class Static57 {
 			}
 		}
 		if (!local22) {
-			Static67.method6098(LocalizedText.FRIEND_UNABLE_TO_FIND.get(Static51.anInt1052) + arg0);
+			Static67.method6098(LocalizedText.FRIEND_UNABLE_TO_FIND.get(Static51.clientLanguageId) + arg0);
 		}
 		if (Static156.aBoolean223) {
 			Static470.method6384();

--- a/client/src/main/java/Static572.java
+++ b/client/src/main/java/Static572.java
@@ -61,7 +61,7 @@ public final class Static572 {
 
 	@OriginalMember(owner = "client!s", name = "b", descriptor = "(III)V")
 	public static void method7876(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1) {
-		@Pc(11) int local11 = Static42.aClass381_4.method8744(LocalizedText.CHOOSE_OPTION.get(Static51.anInt1052));
+		@Pc(11) int local11 = Static42.aClass381_4.method8744(LocalizedText.CHOOSE_OPTION.get(Static51.clientLanguageId));
 		@Pc(68) int local68;
 		@Pc(27) int local27;
 		if (Static236.aBoolean304) {

--- a/client/src/main/java/Static651.java
+++ b/client/src/main/java/Static651.java
@@ -187,8 +187,8 @@ public final class Static651 {
 			return;
 		}
 		if (arg1.anInt10791 != 0) {
-			@Pc(67) String local67 = ModeGame.GAME_STELLARDAWN == Static392.aModeGame4 ? LocalizedText.RATING.get(Static51.anInt1052) : LocalizedText.LEVEL.get(Static51.anInt1052);
-			local24 = local24 + Static693.method9009(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444, arg1.anInt10791) + " (" + local67 + arg1.anInt10791 + ")";
+			@Pc(67) String local67 = ModeGame.GAME_STELLARDAWN == Static392.clientModeGame ? LocalizedText.RATING.get(Static51.clientLanguageId) : LocalizedText.LEVEL.get(Static51.clientLanguageId);
+			local24 = local24 + Static693.levelDifferenceColor(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2, arg1.anInt10791) + " (" + local67 + arg1.anInt10791 + ")";
 		}
 		if (Static156.aBoolean223 && !arg0) {
 			@Pc(113) ParamType local113 = Static610.anInt9329 == -1 ? null : Static386.aParamTypeList2.method1161(Static610.anInt9329);
@@ -207,7 +207,7 @@ public final class Static651 {
 			return;
 		}
 		for (@Pc(189) int local189 = local176.length - 1; local189 >= 0; local189--) {
-			if (local176[local189] != null && (local21.aByte107 == 0 || !local176[local189].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.anInt1052)) && !local176[local189].equalsIgnoreCase(LocalizedText.EXAMINE.get(Static51.anInt1052)))) {
+			if (local176[local189] != null && (local21.aByte107 == 0 || !local176[local189].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.clientLanguageId)) && !local176[local189].equalsIgnoreCase(LocalizedText.EXAMINE.get(Static51.clientLanguageId)))) {
 				@Pc(226) short local226 = 0;
 				@Pc(228) int local228 = Static39.anInt950;
 				if (local189 == 0) {
@@ -234,16 +234,16 @@ public final class Static651 {
 				if (local21.anInt6737 == local189) {
 					local228 = local21.anInt6752;
 				}
-				Static416.method5707(false, -1, (long) arg1.anInt10740, 0, 0, local176[local189], local226, true, local176[local189].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.anInt1052)) ? local21.anInt6740 : local228, "<col=ffff00>" + local24, (long) arg1.anInt10740, false);
+				Static416.method5707(false, -1, (long) arg1.anInt10740, 0, 0, local176[local189], local226, true, local176[local189].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.clientLanguageId)) ? local21.anInt6740 : local228, "<col=ffff00>" + local24, (long) arg1.anInt10740, false);
 			}
 		}
 		if (local21.aByte107 != 1) {
 			return;
 		}
 		for (@Pc(341) int local341 = 0; local341 < local176.length; local341++) {
-			if (local176[local341] != null && (local176[local341].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.anInt1052)) || local176[local341].equalsIgnoreCase(LocalizedText.EXAMINE.get(Static51.anInt1052)))) {
+			if (local176[local341] != null && (local176[local341].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.clientLanguageId)) || local176[local341].equalsIgnoreCase(LocalizedText.EXAMINE.get(Static51.clientLanguageId)))) {
 				@Pc(372) short local372 = 0;
-				if (arg1.anInt10791 > Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.anInt1444) {
+				if (arg1.anInt10791 > Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.combatLevel2) {
 					local372 = 2000;
 				}
 				@Pc(385) short local385 = 0;
@@ -275,7 +275,7 @@ public final class Static651 {
 				if (local21.anInt6737 == local341) {
 					local387 = local21.anInt6752;
 				}
-				Static416.method5707(false, -1, (long) arg1.anInt10740, 0, 0, local176[local341], local385, true, local176[local341].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.anInt1052)) ? local21.anInt6740 : local387, "<col=ffff00>" + local24, (long) arg1.anInt10740, false);
+				Static416.method5707(false, -1, (long) arg1.anInt10740, 0, 0, local176[local341], local385, true, local176[local341].equalsIgnoreCase(LocalizedText.ATTACK.get(Static51.clientLanguageId)) ? local21.anInt6740 : local387, "<col=ffff00>" + local24, (long) arg1.anInt10740, false);
 			}
 		}
 		return;

--- a/client/src/main/java/Static659.java
+++ b/client/src/main/java/Static659.java
@@ -35,7 +35,7 @@ public final class Static659 {
 		if (Static150.aString26 != null) {
 			local44 = "/p=" + Static150.aString26;
 		}
-		return "http://" + local15 + "." + Static392.aModeGame4.name + ".com/l=" + Static51.anInt1052 + "/a=" + Static323.anInt5121 + local44 + "/";
+		return "http://" + local15 + "." + Static392.clientModeGame.name + ".com/l=" + Static51.clientLanguageId + "/a=" + Static323.anInt5121 + local44 + "/";
 	}
 
 	@OriginalMember(owner = "client!ut", name = "d", descriptor = "(B)Lclient!ge;")

--- a/client/src/main/java/Static669.java
+++ b/client/src/main/java/Static669.java
@@ -38,7 +38,7 @@ public final class Static669 {
 			}
 			return local11 - local14;
 		} else if (arg3 == 2) {
-			return Static540.method6538(arg0.method6717().aString13, Static51.anInt1052, arg2.method6717().aString13);
+			return Static540.method6538(arg0.method6717().aString13, Static51.clientLanguageId, arg2.method6717().aString13);
 		} else if (arg3 == 3) {
 			if (arg2.aString91.equals("-")) {
 				if (arg0.aString91.equals("-")) {
@@ -51,7 +51,7 @@ public final class Static669 {
 			} else if (arg0.aString91.equals("-")) {
 				return arg1 ? 1 : -1;
 			} else {
-				return Static540.method6538(arg0.aString91, Static51.anInt1052, arg2.aString91);
+				return Static540.method6538(arg0.aString91, Static51.clientLanguageId, arg2.aString91);
 			}
 		} else if (arg3 == 4) {
 			if (arg2.method6712()) {

--- a/client/src/main/java/Static684.java
+++ b/client/src/main/java/Static684.java
@@ -29,7 +29,7 @@ public final class Static684 {
 			Static164.anInt2808 = 0;
 		}
 		Static81.method1586(arg2);
-		Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052), true, Static694.aClass381_13, Static437.aClass14_9);
+		Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId), true, Static694.aClass381_13, Static437.aClass14_9);
 		@Pc(74) int local74 = Static691.anInt10367;
 		Static691.anInt10367 = (Static62.anInt1465 - (Static720.anInt10859 >> 4)) * 8;
 		@Pc(85) int local85 = Static116.anInt2270;

--- a/client/src/main/java/Static693.java
+++ b/client/src/main/java/Static693.java
@@ -20,7 +20,7 @@ public final class Static693 {
 	public static int anInt10382 = -1;
 
 	@OriginalMember(owner = "client!vu", name = "b", descriptor = "(III)Ljava/lang/String;")
-	public static String method9009(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1) {
+	public static String levelDifferenceColor(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1) {
 		@Pc(8) int local8 = arg0 - arg1;
 		if (local8 < -9) {
 			return "<col=ff0000>";

--- a/client/src/main/java/Static706.java
+++ b/client/src/main/java/Static706.java
@@ -75,7 +75,7 @@ public final class Static706 {
 			return;
 		}
 		if (Static327.anInt5392 >= 200 && !Static126.aBoolean200 || Static327.anInt5392 >= 200) {
-			Static67.method6098(LocalizedText.FRIENDS_FULL.get(Static51.anInt1052));
+			Static67.method6098(LocalizedText.FRIENDS_FULL.get(Static51.clientLanguageId));
 			return;
 		}
 		@Pc(34) String local34 = Static390.method5492(arg0);
@@ -86,13 +86,13 @@ public final class Static706 {
 		for (@Pc(40) int local40 = 0; local40 < Static327.anInt5392; local40++) {
 			@Pc(47) String local47 = Static390.method5492(Static330.aStringArray25[local40]);
 			if (local47 != null && local47.equals(local34)) {
-				Static67.method6098(arg0 + LocalizedText.FRIEND_ALREADY_ADDED.get(Static51.anInt1052));
+				Static67.method6098(arg0 + LocalizedText.FRIEND_ALREADY_ADDED.get(Static51.clientLanguageId));
 				return;
 			}
 			if (Static572.aStringArray42[local40] != null) {
 				local81 = Static390.method5492(Static572.aStringArray42[local40]);
 				if (local81 != null && local81.equals(local34)) {
-					Static67.method6098(arg0 + LocalizedText.FRIEND_ALREADY_ADDED.get(Static51.anInt1052));
+					Static67.method6098(arg0 + LocalizedText.FRIEND_ALREADY_ADDED.get(Static51.clientLanguageId));
 					return;
 				}
 			}
@@ -100,19 +100,19 @@ public final class Static706 {
 		for (@Pc(115) int local115 = 0; local115 < Static436.anInt3849; local115++) {
 			local81 = Static390.method5492(Static632.aStringArray44[local115]);
 			if (local81 != null && local81.equals(local34)) {
-				Static67.method6098(LocalizedText.IGNORE_REMOVE_PRE.get(Static51.anInt1052) + arg0 + LocalizedText.IGNORE_REMOVE_POST.get(Static51.anInt1052));
+				Static67.method6098(LocalizedText.IGNORE_REMOVE_PRE.get(Static51.clientLanguageId) + arg0 + LocalizedText.IGNORE_REMOVE_POST.get(Static51.clientLanguageId));
 				return;
 			}
 			if (Static10.aStringArray1[local115] != null) {
 				@Pc(161) String local161 = Static390.method5492(Static10.aStringArray1[local115]);
 				if (local161 != null && local161.equals(local34)) {
-					Static67.method6098(LocalizedText.IGNORE_REMOVE_PRE.get(Static51.anInt1052) + arg0 + LocalizedText.IGNORE_REMOVE_POST.get(Static51.anInt1052));
+					Static67.method6098(LocalizedText.IGNORE_REMOVE_PRE.get(Static51.clientLanguageId) + arg0 + LocalizedText.IGNORE_REMOVE_POST.get(Static51.clientLanguageId));
 					return;
 				}
 			}
 		}
-		if (Static390.method5492(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.aString9).equals(local34)) {
-			Static67.method6098(LocalizedText.FRIEND_CANNOT_ADD_SELF.get(Static51.anInt1052));
+		if (Static390.method5492(Static556.aClass8_Sub2_Sub1_Sub2_Sub1_2.name2).equals(local34)) {
+			Static67.method6098(LocalizedText.FRIEND_CANNOT_ADD_SELF.get(Static51.clientLanguageId));
 			return;
 		}
 		@Pc(230) Connection local230 = Connection.getActiveConnection();

--- a/client/src/main/java/Static709.java
+++ b/client/src/main/java/Static709.java
@@ -35,7 +35,7 @@ public final class Static709 {
 		@Pc(27) Class140 local27 = Static473.aClass140_22;
 		@Pc(35) int local35 = client.method3448();
 		if (Static473.aClass140_22 == local27) {
-			Static579.aString106 = Static473.aClass140_22.aLocalizedText_63.get(Static51.anInt1052);
+			Static579.aString106 = Static473.aClass140_22.aLocalizedText_63.get(Static51.clientLanguageId);
 			if (Static473.aClass140_22.aBoolean264) {
 				Static376.anInt5919 = Static473.aClass140_22.anInt3271 + local35 * (Static473.aClass140_22.anInt3270 - Static473.aClass140_22.anInt3271) / 100;
 			}
@@ -46,7 +46,7 @@ public final class Static709 {
 			Static449.aClass364_1 = null;
 			Static81.method1586(3);
 		} else {
-			Static579.aString106 = local27.aLocalizedText_64.get(Static51.anInt1052);
+			Static579.aString106 = local27.aLocalizedText_64.get(Static51.clientLanguageId);
 			if (Static473.aClass140_22.aBoolean263) {
 				Static579.aString106 = Static579.aString106 + local27.anInt3270 + "%";
 			}
@@ -551,10 +551,10 @@ public final class Static709 {
 											for (@Pc(2281) SecondaryParticleNode_Sub1 local2281 = (SecondaryParticleNode_Sub1) Static168.aParticleLinkedList5.method2790(); local2281 != null; local2281 = (SecondaryParticleNode_Sub1) Static168.aParticleLinkedList5.method2785()) {
 												if (Static588.method7715() / 1000L - 5L > (long) local2281.anInt6433) {
 													if (local2281.aShort74 > 0) {
-														Static44.method1072(local2281.aString72 + LocalizedText.FRIEND_LOGGED_IN.get(Static51.anInt1052), "", 0, "", "", 5);
+														Static44.method1072(local2281.aString72 + LocalizedText.FRIEND_LOGGED_IN.get(Static51.clientLanguageId), "", 0, "", "", 5);
 													}
 													if (local2281.aShort74 == 0) {
-														Static44.method1072(local2281.aString72 + LocalizedText.FRIEND_LOGGED_OUT.get(Static51.anInt1052), "", 0, "", "", 5);
+														Static44.method1072(local2281.aString72 + LocalizedText.FRIEND_LOGGED_OUT.get(Static51.clientLanguageId), "", 0, "", "", 5);
 													}
 													local2281.method9274();
 												}

--- a/client/src/main/java/Static71.java
+++ b/client/src/main/java/Static71.java
@@ -330,7 +330,7 @@ public final class Static71 {
 											}
 										}
 										if (local19 == Static390.aComponent9) {
-											local1533 = LocalizedText.PLEASE_WAIT.get(Static51.anInt1052);
+											local1533 = LocalizedText.PLEASE_WAIT.get(Static51.clientLanguageId);
 											local323 = local19.anInt3779;
 										}
 										if (Static376.aBoolean452) {
@@ -446,7 +446,7 @@ public final class Static71 {
 										local1255 = local19.anInt3831;
 										if (local1255 >= 0 && local1255 < 2048) {
 											@Pc(2341) Player local2341 = Static621.aClass8_Sub2_Sub1_Sub2_Sub1Array3[local1255];
-											if (local2341 != null && (local1255 == Static312.anInt5000 || Static214.method3157(local2341.aString9) == local19.anInt3738)) {
+											if (local2341 != null && (local1255 == Static312.anInt5000 || Static214.method3157(local2341.name2) == local19.anInt3738)) {
 												local2313 = local2341.aPlayerAppearance1.method4546(ObjTypeList.objTypes, local19.aClass152_6, Static574.aBasTypeList2, Static25.aSeqTypeList1, 2048, (int[]) null, Static125.aClass388_1, Static68.aIdkTypeList3, Static163.aClass19_17, Static690.aNpcTypeList2, (Class152[]) null, 0, (Class152) null, Static34.aClass304_1);
 											}
 										}

--- a/client/src/main/java/Static720.java
+++ b/client/src/main/java/Static720.java
@@ -54,7 +54,7 @@ public final class Static720 {
 	@OriginalMember(owner = "client!wr", name = "a", descriptor = "(I)Lclient!kv;")
 	public static Preferences method9398() {
 		@Pc(13) FileOnDisk local13 = null;
-		@Pc(19) Preferences local19 = new Preferences(Static392.aModeGame4, 0);
+		@Pc(19) Preferences local19 = new Preferences(Static392.clientModeGame, 0);
 		try {
 			@Pc(25) PrivilegedRequest local25 = Static446.aSignlink6.method8981("");
 			while (local25.anInt6789 == 0) {
@@ -70,7 +70,7 @@ public final class Static720 {
 						throw new IOException("EOF");
 					}
 				}
-				local19 = new Preferences(new Packet(local51), Static392.aModeGame4, 0);
+				local19 = new Preferences(new Packet(local51), Static392.clientModeGame, 0);
 			}
 		} catch (@Pc(97) Exception local97) {
 		}

--- a/client/src/main/java/Static81.java
+++ b/client/src/main/java/Static81.java
@@ -123,8 +123,8 @@ public final class Static81 {
 		local8.buffer.p2(Static323.anInt5121);
 		local8.buffer.pjstr(arg2);
 		local8.buffer.p8(Static416.aLong208);
-		local8.buffer.p1(Static51.anInt1052);
-		local8.buffer.p1(Static392.aModeGame4.id);
+		local8.buffer.p1(Static51.clientLanguageId);
+		local8.buffer.p1(Static392.clientModeGame.id);
 		Static176.method6690(local8.buffer);
 		@Pc(81) String local81 = Static389.aString64;
 		local8.buffer.p1(local81 == null ? 0 : 1);

--- a/client/src/main/java/Static84.java
+++ b/client/src/main/java/Static84.java
@@ -641,8 +641,8 @@ public final class Static84 {
 											}
 											continue;
 										}
-										if (Static392.aModeGame4 == ModeGame.GAME_STELLARDAWN) {
-											Static416.method5707(false, -1, 1L, local1191, local1199, LocalizedText.FACE_HERE.get(Static51.anInt1052), 11, true, -1, "", 0L, true);
+										if (Static392.clientModeGame == ModeGame.GAME_STELLARDAWN) {
+											Static416.method5707(false, -1, 1L, local1191, local1199, LocalizedText.FACE_HERE.get(Static51.clientLanguageId), 11, true, -1, "", 0L, true);
 										}
 										Static416.method5707(false, -1, 1L, local1191, local1199, Static331.aString52, 58, true, Static331.anInt5439, "", 0L, true);
 										continue;
@@ -998,7 +998,7 @@ public final class Static84 {
 								}
 								@Pc(2824) SubInterface local2824 = (SubInterface) Static548.aHashTable40.get((long) local6.anInt3812);
 								if (local2824 != null) {
-									if (Static392.aModeGame4 == ModeGame.GAME_RUNESCAPE && local2824.anInt146 == 0 && !Static400.aBoolean622 && local310 && !Static103.aBoolean195) {
+									if (Static392.clientModeGame == ModeGame.GAME_RUNESCAPE && local2824.anInt146 == 0 && !Static400.aBoolean622 && local310 && !Static103.aBoolean195) {
 										Static79.method1578();
 									}
 									Static431.method5822(local36, local24, local32, arg9, arg11, local34, local19, local2824.anInt147, arg8, arg10, local30);

--- a/client/src/main/java/Static93.java
+++ b/client/src/main/java/Static93.java
@@ -27,7 +27,7 @@ public final class Static93 {
 			local57 = arg2 + arg0 / 2 - 20 - 18;
 			arg4.method7976(local38 - 152, local57, 304, 34, Static337.aColorArray1[Static338.anInt5562].getRGB(), 0);
 			arg4.aa(local38 - 150, local57 + 2, Static273.anInt4403 * 3, 30, Static718.aColorArray3[Static338.anInt5562].getRGB(), 0);
-			Static180.aClass14_3.method8828(-1, local38, LocalizedText.LOADING.get(Static51.anInt1052), local57 + 20, Static399.aColorArray2[Static338.anInt5562].getRGB());
+			Static180.aClass14_3.method8828(-1, local38, LocalizedText.LOADING.get(Static51.clientLanguageId), local57 + 20, Static399.aColorArray2[Static338.anInt5562].getRGB());
 			return;
 		}
 		@Pc(114) int local114 = Static164.anInt2809 - (int) ((float) arg5 / Static30.aFloat105);

--- a/client/src/main/java/client.java
+++ b/client/src/main/java/client.java
@@ -126,12 +126,12 @@ public final class client extends GameShell {
 			} else {
 				Static426.method1016("modewhat");
 			}
-			Static51.anInt1052 = Static541.method7198(arg0[4]);
-			if (Static51.anInt1052 == -1) {
+			Static51.clientLanguageId = Static541.method7198(arg0[4]);
+			if (Static51.clientLanguageId == -1) {
 				if (arg0[4].equals("english")) {
-					Static51.anInt1052 = 0;
+					Static51.clientLanguageId = 0;
 				} else if (arg0[4].equals("german")) {
-					Static51.anInt1052 = 1;
+					Static51.clientLanguageId = 1;
 				} else {
 					Static426.method1016("language");
 				}
@@ -139,13 +139,13 @@ public final class client extends GameShell {
 			Static464.aBoolean533 = false;
 			Static98.aBoolean191 = false;
 			if (arg0[5].equals("game0")) {
-				Static392.aModeGame4 = ModeGame.GAME_RUNESCAPE;
+				Static392.clientModeGame = ModeGame.GAME_RUNESCAPE;
 			} else if (arg0[5].equals("game1")) {
-				Static392.aModeGame4 = ModeGame.GAME_STELLARDAWN;
+				Static392.clientModeGame = ModeGame.GAME_STELLARDAWN;
 			} else if (arg0[5].equals("game2")) {
-				Static392.aModeGame4 = ModeGame.GAME_3;
+				Static392.clientModeGame = ModeGame.GAME_3;
 			} else if (arg0[5].equals("game3")) {
-				Static392.aModeGame4 = ModeGame.GAME_4;
+				Static392.clientModeGame = ModeGame.GAME_4;
 			} else {
 				Static426.method1016("game");
 			}
@@ -156,14 +156,14 @@ public final class client extends GameShell {
 			Static126.aBoolean200 = true;
 			Static473.aBoolean539 = false;
 			Static389.aString64 = null;
-			Static338.anInt5562 = Static392.aModeGame4.id;
+			Static338.anInt5562 = Static392.clientModeGame.id;
 			Static150.aString26 = "";
 			Static265.aByteArray44 = null;
 			Static584.anInt8634 = 0;
 			Static416.aLong208 = 0L;
 			@Pc(241) client local241 = new client();
 			Static295.aClient1 = local241;
-			local241.method1635(Static598.aClass162_5.method3469() + 32, Static392.aModeGame4.name);
+			local241.method1635(Static598.aClass162_5.method3469() + 32, Static392.clientModeGame.name);
 			Static353.aFrame10.setLocation(40, 40);
 		} catch (@Pc(265) Exception local265) {
 			Static240.method3496(local265, (String) null);
@@ -237,7 +237,7 @@ public final class client extends GameShell {
 			Static466.loadingScreenChecksum = loadingScreen.getChecksum();
 			Static616.method8284(loadingSprites);
 			@Pc(250) int local250 = Static400.aClass2_Sub34_28.aPreference_Sub11_1.method3603();
-			Static333.aClass279_1 = new Class279(Static392.aModeGame4, Static51.anInt1052, loadingScreen);
+			Static333.aClass279_1 = new Class279(Static392.clientModeGame, Static51.clientLanguageId, loadingScreen);
 			@Pc(262) int[] local262 = Static333.aClass279_1.method6275(local250);
 			if (local262.length == 0) {
 				local262 = Static333.aClass279_1.method6275(0);
@@ -357,37 +357,37 @@ public final class client extends GameShell {
 				return 99;
 			}
 			Static56.anInterface4_3 = new Js5TextureProvider(materials, textures, sprites);
-			Static386.aParamTypeList2 = new ParamTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static574.aBasTypeList2 = new BasTypeList(Static392.aModeGame4, Static51.anInt1052, config, Static125.aClass388_1);
-			Static354.aCursorTypeList1 = new CursorTypeList(Static392.aModeGame4, Static51.anInt1052, config, sprites);
-			Static619.aEnumTypeList2 = new EnumTypeList(Static392.aModeGame4, Static51.anInt1052, configEnum);
-			Static467.aFloTypeList3 = new FloTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static540.aFluTypeList6 = new FluTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static561.aHitmarkTypeList2 = new HitmarkTypeList(Static392.aModeGame4, Static51.anInt1052, config, sprites);
-			Static68.aIdkTypeList3 = new IdkTypeList(Static392.aModeGame4, Static51.anInt1052, config, models);
-			Static503.aInvTypeList1 = new InvTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static48.aLightTypeList1 = new LightTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static354.aLocTypeList4 = new LocTypeList(Static392.aModeGame4, Static51.anInt1052, true, configLoc, models);
-			Static577.aMelTypeList4 = new MelTypeList(Static392.aModeGame4, Static51.anInt1052, config, sprites);
-			Static720.aMsiTypeList4 = new MsiTypeList(Static392.aModeGame4, Static51.anInt1052, config, sprites);
-			Static690.aNpcTypeList2 = new NpcTypeList(Static392.aModeGame4, Static51.anInt1052, true, configNpc, models);
-			ObjTypeList.objTypes = new ObjTypeList(Static392.aModeGame4, Static51.anInt1052, true, Static386.aParamTypeList2, configObj, models);
-			Static272.aQuestTypeList1 = new QuestTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static25.aSeqTypeList1 = new SeqTypeList(Static392.aModeGame4, Static51.anInt1052, configSeq, anims, bases);
-			Static324.aSkyBoxTypeList1 = new SkyBoxTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static99.aSkyBoxSphereTypeList1 = new SkyBoxSphereTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static23.aSpotAnimTypeList1 = new SpotAnimTypeList(Static392.aModeGame4, Static51.anInt1052, configSpot, models);
-			Static652.aStructTypeList1 = new StructTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static718.aVarClientStrTypeList1 = new VarClientStrTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static691.aVarClientTypeList1 = new VarClientTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static529.aVarBitTypeList1 = new VarBitTypeList(Static392.aModeGame4, Static51.anInt1052, configVarbit);
-			Static36.aVarPlayerTypeList1 = new VarPlayerTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static628.aVarClanTypeList5 = new VarClanTypeList(Static392.aModeGame4, Static51.anInt1052, config);
-			Static648.aVarClanSettingTypeList1 = new VarClanSettingTypeList(Static392.aModeGame4, Static51.anInt1052, config);
+			Static386.aParamTypeList2 = new ParamTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static574.aBasTypeList2 = new BasTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, Static125.aClass388_1);
+			Static354.aCursorTypeList1 = new CursorTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, sprites);
+			Static619.aEnumTypeList2 = new EnumTypeList(Static392.clientModeGame, Static51.clientLanguageId, configEnum);
+			Static467.aFloTypeList3 = new FloTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static540.aFluTypeList6 = new FluTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static561.aHitmarkTypeList2 = new HitmarkTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, sprites);
+			Static68.aIdkTypeList3 = new IdkTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, models);
+			Static503.aInvTypeList1 = new InvTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static48.aLightTypeList1 = new LightTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static354.aLocTypeList4 = new LocTypeList(Static392.clientModeGame, Static51.clientLanguageId, true, configLoc, models);
+			Static577.aMelTypeList4 = new MelTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, sprites);
+			Static720.aMsiTypeList4 = new MsiTypeList(Static392.clientModeGame, Static51.clientLanguageId, config, sprites);
+			Static690.aNpcTypeList2 = new NpcTypeList(Static392.clientModeGame, Static51.clientLanguageId, true, configNpc, models);
+			ObjTypeList.objTypes = new ObjTypeList(Static392.clientModeGame, Static51.clientLanguageId, true, Static386.aParamTypeList2, configObj, models);
+			Static272.aQuestTypeList1 = new QuestTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static25.aSeqTypeList1 = new SeqTypeList(Static392.clientModeGame, Static51.clientLanguageId, configSeq, anims, bases);
+			Static324.aSkyBoxTypeList1 = new SkyBoxTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static99.aSkyBoxSphereTypeList1 = new SkyBoxSphereTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static23.aSpotAnimTypeList1 = new SpotAnimTypeList(Static392.clientModeGame, Static51.clientLanguageId, configSpot, models);
+			Static652.aStructTypeList1 = new StructTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static718.aVarClientStrTypeList1 = new VarClientStrTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static691.aVarClientTypeList1 = new VarClientTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static529.aVarBitTypeList1 = new VarBitTypeList(Static392.clientModeGame, Static51.clientLanguageId, configVarbit);
+			Static36.aVarPlayerTypeList1 = new VarPlayerTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static628.aVarClanTypeList5 = new VarClanTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
+			Static648.aVarClanSettingTypeList1 = new VarClanSettingTypeList(Static392.clientModeGame, Static51.clientLanguageId, config);
 			Static444.method5987(interfaces, fontMetrics, sprites, models);
 			Static110.method2081(configBillboard);
-			Static68.aQuickChatCatTypeList3 = new QuickChatCatTypeList(Static51.anInt1052, quickchat, quickchatGlobal);
-			Static288.aQuickChatPhraseTypeList2 = new QuickChatPhraseTypeList(Static51.anInt1052, quickchat, quickchatGlobal, new Js5QuickChatCommandDecoder());
+			Static68.aQuickChatCatTypeList3 = new QuickChatCatTypeList(Static51.clientLanguageId, quickchat, quickchatGlobal);
+			Static288.aQuickChatPhraseTypeList2 = new QuickChatPhraseTypeList(Static51.clientLanguageId, quickchat, quickchatGlobal, new Js5QuickChatCommandDecoder());
 			Static412.method5693();
 			Static354.aLocTypeList4.setLowDetail(Static400.aClass2_Sub34_28.aPreference_Sub19_2.method5960() == 0);
 			Static34.aClass304_1 = new Class304();
@@ -747,10 +747,10 @@ public final class client extends GameShell {
 											for (@Pc(672) SecondaryParticleNode_Sub1 local672 = (SecondaryParticleNode_Sub1) Static168.aParticleLinkedList5.method2790(); local672 != null; local672 = (SecondaryParticleNode_Sub1) Static168.aParticleLinkedList5.method2785()) {
 												if ((long) local672.anInt6433 < Static588.method7715() / 1000L - 5L) {
 													if (local672.aShort74 > 0) {
-														Static44.method1072(local672.aString72 + LocalizedText.FRIEND_LOGGED_IN.get(Static51.anInt1052), "", 0, "", "", 5);
+														Static44.method1072(local672.aString72 + LocalizedText.FRIEND_LOGGED_IN.get(Static51.clientLanguageId), "", 0, "", "", 5);
 													}
 													if (local672.aShort74 == 0) {
-														Static44.method1072(local672.aString72 + LocalizedText.FRIEND_LOGGED_OUT.get(Static51.anInt1052), "", 0, "", "", 5);
+														Static44.method1072(local672.aString72 + LocalizedText.FRIEND_LOGGED_OUT.get(Static51.clientLanguageId), "", 0, "", "", 5);
 													}
 													local672.method9274();
 												}
@@ -895,22 +895,22 @@ public final class client extends GameShell {
 					Static357.anInt6508 = Static593.anInt8763;
 				}
 				local110 = (Static357.anInt6508 - Static593.anInt8763) * 50 / Static357.anInt6508;
-				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052) + "<br>(" + local110 + "%)", true, Static694.aClass381_13, Static437.aClass14_9);
+				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId) + "<br>(" + local110 + "%)", true, Static694.aClass381_13, Static437.aClass14_9);
 			} else if (Static213.anInt3472 == 2) {
 				if (Static13.anInt150 > Static440.anInt6683) {
 					Static440.anInt6683 = Static13.anInt150;
 				}
 				local110 = (Static440.anInt6683 - Static13.anInt150) * 50 / Static440.anInt6683 + 50;
-				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052) + "<br>(" + local110 + "%)", true, Static694.aClass381_13, Static437.aClass14_9);
+				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId) + "<br>(" + local110 + "%)", true, Static694.aClass381_13, Static437.aClass14_9);
 			} else {
-				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052), true, Static694.aClass381_13, Static437.aClass14_9);
+				Static694.method9028(Static163.aClass19_17, LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId), true, Static694.aClass381_13, Static437.aClass14_9);
 			}
 		} else if (Static283.gameState == 11) {
 			Static686.method7930(local20);
 		} else if (Static283.gameState == 14) {
-			Static694.method9028(Static163.aClass19_17, LocalizedText.CONNECTION_LOST.get(Static51.anInt1052) + "<br>" + LocalizedText.CONNECTION_REESTABLISH.get(Static51.anInt1052), false, Static694.aClass381_13, Static437.aClass14_9);
+			Static694.method9028(Static163.aClass19_17, LocalizedText.CONNECTION_LOST.get(Static51.clientLanguageId) + "<br>" + LocalizedText.CONNECTION_REESTABLISH.get(Static51.clientLanguageId), false, Static694.aClass381_13, Static437.aClass14_9);
 		} else if (Static283.gameState == 15) {
-			Static694.method9028(Static163.aClass19_17, LocalizedText.PLEASE_WAIT.get(Static51.anInt1052), false, Static694.aClass381_13, Static437.aClass14_9);
+			Static694.method9028(Static163.aClass19_17, LocalizedText.PLEASE_WAIT.get(Static51.clientLanguageId), false, Static694.aClass381_13, Static437.aClass14_9);
 		}
 		if (Static18.anInt251 == 3) {
 			for (local110 = 0; local110 < Static122.anInt2339; local110++) {
@@ -1143,7 +1143,7 @@ public final class client extends GameShell {
 		}
 		Static344.aClass229_1 = Static527.aClass229_3;
 		Static637.aShortArray132 = Static419.aShortArray96 = Static553.aShortArray112 = Static238.aShortArray62 = new short[256];
-		if (Static392.aModeGame4 == ModeGame.GAME_RUNESCAPE) {
+		if (Static392.clientModeGame == ModeGame.GAME_RUNESCAPE) {
 			Static273.aBoolean340 = false;
 		}
 		try {
@@ -1175,7 +1175,7 @@ public final class client extends GameShell {
 		if (ModeWhere.LIVE != Static2.aModeWhere1 && !ClientConfig.DISABLE_DEFAULT_FPSON) {
 			Static105.aBoolean196 = true;
 		}
-		Static484.aString85 = LocalizedText.LOADING_PLEASE_WAIT.get(Static51.anInt1052);
+		Static484.aString85 = LocalizedText.LOADING_PLEASE_WAIT.get(Static51.clientLanguageId);
 	}
 
 	@OriginalMember(owner = "client!client", name = "a", descriptor = "(I)Ljava/lang/String;")
@@ -1257,9 +1257,9 @@ public final class client extends GameShell {
 			Static598.aClass162_5 = Static523.aClass162_3;
 		}
 		try {
-			Static51.anInt1052 = Integer.parseInt(this.getParameter("lang"));
+			Static51.clientLanguageId = Integer.parseInt(this.getParameter("lang"));
 		} catch (@Pc(110) Exception local110) {
-			Static51.anInt1052 = 0;
+			Static51.clientLanguageId = 0;
 		}
 		@Pc(118) String local118 = this.getParameter("objecttag");
 		if (local118 != null && local118.equals("1")) {
@@ -1282,13 +1282,13 @@ public final class client extends GameShell {
 		@Pc(190) String local190 = this.getParameter("game");
 		if (local190 != null) {
 			if (local190.equals("0")) {
-				Static392.aModeGame4 = ModeGame.GAME_RUNESCAPE;
+				Static392.clientModeGame = ModeGame.GAME_RUNESCAPE;
 			} else if (local190.equals("1")) {
-				Static392.aModeGame4 = ModeGame.GAME_STELLARDAWN;
+				Static392.clientModeGame = ModeGame.GAME_STELLARDAWN;
 			} else if (local190.equals("2")) {
-				Static392.aModeGame4 = ModeGame.GAME_3;
+				Static392.clientModeGame = ModeGame.GAME_3;
 			} else if (local190.equals("3")) {
-				Static392.aModeGame4 = ModeGame.GAME_4;
+				Static392.clientModeGame = ModeGame.GAME_4;
 			}
 		}
 		try {
@@ -1351,10 +1351,10 @@ public final class client extends GameShell {
 		if (Static389.aString64 != null && Static389.aString64.length() > 50) {
 			Static389.aString64 = null;
 		}
-		if (ModeGame.GAME_RUNESCAPE == Static392.aModeGame4) {
+		if (ModeGame.GAME_RUNESCAPE == Static392.clientModeGame) {
 			Static302.anInt4851 = 765;
 			Static479.anInt7201 = 503;
-		} else if (Static392.aModeGame4 == ModeGame.GAME_STELLARDAWN) {
+		} else if (Static392.clientModeGame == ModeGame.GAME_STELLARDAWN) {
 			Static479.anInt7201 = 480;
 			Static302.anInt4851 = 640;
 		}
@@ -1363,7 +1363,7 @@ public final class client extends GameShell {
 			Static416.aBoolean473 = true;
 		}
 		Static295.aClient1 = this;
-		this.method1640(Static302.anInt4851, Static598.aClass162_5.method3469() + 32, Static392.aModeGame4.name, Static479.anInt7201);
+		this.method1640(Static302.anInt4851, Static598.aClass162_5.method3469() + 32, Static392.clientModeGame.name, Static479.anInt7201);
 	}
 
 	@OriginalMember(owner = "client!client", name = "c", descriptor = "(I)V")


### PR DESCRIPTION
Seems the Player class has 2 different names and 2 different combat levels. 

It looks like one of the combat levels should be with summoning and the other without based on Class414.method5696 but in debugging I can only see them as the same value even when in the wilderness.

Not sure if there's any difference between the 2 player names.

Open to different names for these